### PR TITLE
Fix ROI calculator next step navigation issue

### DIFF
--- a/website/pages/tools/roi-calculator.html
+++ b/website/pages/tools/roi-calculator.html
@@ -590,7 +590,7 @@
                 steps.forEach(step => step.style.display = 'none');
                 
                 // Show current step
-                const currentStepElement = document.querySelector(`[data-step="${currentStep}"]`);
+                const currentStepElement = document.querySelector(`.form-step[data-step="${currentStep}"]`);
                 if (currentStepElement) {
                     currentStepElement.style.display = 'block';
                 }
@@ -612,7 +612,7 @@
             }
             
             function validateCurrentStep() {
-                const currentStepElement = document.querySelector(`[data-step="${currentStep}"]`);
+                const currentStepElement = document.querySelector(`.form-step[data-step="${currentStep}"]`);
                 const requiredFields = currentStepElement.querySelectorAll('input[required], select[required]');
                 
                 for (let field of requiredFields) {


### PR DESCRIPTION
Fixed JavaScript selector bug preventing users from proceeding to next step in the multi-step ROI calculator form.

The issue was caused by a generic `[data-step="${currentStep}"]` selector that matched both step indicators and form steps, causing navigation to fail. Fixed by making the selector specific to form steps: `.form-step[data-step="${currentStep}"]`.

Fixes #7

🤖 Generated with [Claude Code](https://claude.ai/code)