### PR TITLE
fix: Cookie consent banner positioning as proper modal

### DIFF
--- a/website/assets/css/main.css
+++ b/website/assets/css/main.css
@@ -1919,11 +1919,13 @@ html {
     box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.3);
     transform: translateY(100%);
     transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    z-index: 9999;
+    z-index: 999999;
     border-top: 3px solid var(--warm-gold);
+    display: none;
 }
 
 .cookie-banner.show {
+    display: block !important;
     transform: translateY(0);
 }
 
@@ -2023,7 +2025,7 @@ html {
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 10000;
+    z-index: 9999999;
     opacity: 0;
     visibility: hidden;
     transition: all 0.3s ease;

--- a/website/assets/js/main.js
+++ b/website/assets/js/main.js
@@ -488,8 +488,12 @@ class CookieConsent {
     showBanner() {
         const banner = document.getElementById('cookie-banner');
         if (banner) {
-            banner.classList.add('show', 'animate-in');
-            banner.focus();
+            banner.style.display = 'block';
+            // Small delay to ensure display is set before animation
+            setTimeout(() => {
+                banner.classList.add('show', 'animate-in');
+                banner.focus();
+            }, 10);
         }
     }
 


### PR DESCRIPTION
Fixes cookie consent banner positioning to display as proper modal overlay instead of below footer.

- Increase z-index from 9999 to 999999 for better overlay display
- Add display control to ensure banner shows properly as modal
- Update JavaScript to set display: block before animation
- Increase modal z-index to 9999999 to display over banner

Resolves #15

🤖 Generated with [Claude Code](https://claude.ai/code)